### PR TITLE
Do not change ownership of host keys directory

### DIFF
--- a/src/rootfs/entrypoint.sh
+++ b/src/rootfs/entrypoint.sh
@@ -182,7 +182,6 @@ fi
 debug_print "Changing ownership of all files and directories..."
 chown "${PUID}:${PGID}" \
     "${ssh_user_home}" \
-    "${ssh_host_key_dir}" \
     "${ssh_user_home}/.ssh" \
     "${ssh_user_home}/.ssh/authorized_keys"
 chmod 700 \


### PR DESCRIPTION
This line was preventing me from mounting my own persistent host keys. I also don't think it should be owned by the unprivileged tunnel user.