### PR TITLE
Create .env.example to help with copy pasta deployments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,11 @@
-# Content of allowed IP addresses (see below)	AllowUsers tunnel (allow the tunnel user from any IP)
+# Content of allowed IP addresses
+# To specific ips use something like bellow
 # eg. ALLOWED_IPS="AllowUsers *@192.168.1.0/24 *@172.16.0.1 *@10.0.*.1"
+# The default (bellow) allow the tunnel user from any IP
 ALLOWED_IPS="AllowUsers tunnel"
-# 🚨 Required to be set by you. Content of your authorized keys file (see below)	
+# 🚨 Required to be set by you. Content of your authorized keys file
 # eg. AUTHORIZED_KEYS="$(cat .ssh/my_many_ssh_public_keys_in_one_file.txt)"
-AUTHORIZED_KEYS="AUTHORIZED_KEYS"
+AUTHORIZED_KEYS="REQUIRED_TO_BE_SET_BY_YOU"
 # Display a bunch of helpful content for debugging.
 DEBUG="true"
 # Group ID the SSH user should run as.

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,19 @@
+# Content of allowed IP addresses (see below)	AllowUsers tunnel (allow the tunnel user from any IP)
+ALLOWED_IPS="ALLOWED_IPS"
+# 🚨 Required to be set by you. Content of your authorized keys file (see below)	
+# eg. AUTHORIZED_KEYS="$(cat .ssh/my_many_ssh_public_keys_in_one_file.txt)"
+AUTHORIZED_KEYS="AUTHORIZED_KEYS"
+# Display a bunch of helpful content for debugging.
+DEBUG="true"
+# Group ID the SSH user should run as.
+PGID="9999"
+# User ID the SSH user should run as.
+PUID="9999"
+# Group name used for our SSH user.
+SSH_GROUP="tunnelgroup"
+# Location of where the SSH host keys should be stored.
+SSH_HOST_KEY_DIR="/etc/ssh/ssh_host_keys/"
+# Listening port for SSH server (on container only. You'll still need to publish this port).
+SSH_PORT="2222"
+# Username for the SSH user that other users will connect into as.
+SSH_USER="tunnel"

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Content of allowed IP addresses (see below)	AllowUsers tunnel (allow the tunnel user from any IP)
 # eg. ALLOWED_IPS="AllowUsers *@192.168.1.0/24 *@172.16.0.1 *@10.0.*.1"
-ALLOWED_IPS="ALLOWED_IPS"
+ALLOWED_IPS="AllowUsers tunnel"
 # 🚨 Required to be set by you. Content of your authorized keys file (see below)	
 # eg. AUTHORIZED_KEYS="$(cat .ssh/my_many_ssh_public_keys_in_one_file.txt)"
 AUTHORIZED_KEYS="AUTHORIZED_KEYS"

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 # Content of allowed IP addresses (see below)	AllowUsers tunnel (allow the tunnel user from any IP)
+# eg. ALLOWED_IPS="AllowUsers *@192.168.1.0/24 *@172.16.0.1 *@10.0.*.1"
 ALLOWED_IPS="ALLOWED_IPS"
 # 🚨 Required to be set by you. Content of your authorized keys file (see below)	
 # eg. AUTHORIZED_KEYS="$(cat .ssh/my_many_ssh_public_keys_in_one_file.txt)"


### PR DESCRIPTION
Add example environment variables for docker-shh configuration.